### PR TITLE
feat(rfc-00): define requests for comments

### DIFF
--- a/src/rfc/rfc-00.bib
+++ b/src/rfc/rfc-00.bib
@@ -1,0 +1,105 @@
+@report{RFC7322,
+  type = {Request for Comments},
+  title = {{{RFC Style Guide}}},
+  author = {Editor, R. F. C. and Flanagan, Heather},
+  date = {2014-09},
+  number = {RFC 7322},
+  institution = {Internet Engineering Task Force},
+  doi = {10.17487/RFC7322},
+  url = {https://datatracker.ietf.org/doc/rfc7322},
+  urldate = {2025-01-03},
+  abstract = {This document describes the fundamental and unique style conventions and editorial policies currently in use for the RFC Series. It captures the RFC Editor's basic requirements and offers guidance regarding the style and structure of an RFC. Additional guidance is captured on a website that reflects the experimental nature of that guidance and prepares it for future inclusion in the RFC Style Guide. This document obsoletes RFC 2223, "Instructions to RFC Authors".},
+  pagetotal = {24},
+  file = {C:\Users\victo\Zotero\storage\BYTURAF8\Editor and Flanagan - 2014 - RFC Style Guide.pdf}
+}
+
+@report{RFC7230,
+  type = {Request for Comments},
+  title = {Hypertext {{Transfer Protocol}} ({{HTTP}}/1.1): {{Message Syntax}} and {{Routing}}},
+  shorttitle = {Hypertext {{Transfer Protocol}} ({{HTTP}}/1.1)},
+  author = {Fielding, Roy T. and Reschke, Julian},
+  date = {2014-06},
+  number = {RFC 7230},
+  institution = {Internet Engineering Task Force},
+  doi = {10.17487/RFC7230},
+  url = {https://datatracker.ietf.org/doc/rfc7230},
+  urldate = {2025-01-03},
+  abstract = {The Hypertext Transfer Protocol (HTTP) is a stateless application-level protocol for distributed, collaborative, hypertext information systems. This document provides an overview of HTTP architecture and its associated terminology, defines the "http" and "https" Uniform Resource Identifier (URI) schemes, defines the HTTP/1.1 message syntax and parsing requirements, and describes related security concerns for implementations.},
+  pagetotal = {89},
+  file = {C:\Users\victo\Zotero\storage\VATPZARQ\Fielding and Reschke - 2014 - Hypertext Transfer Protocol (HTTP1.1) Message Syntax and Routing.pdf}
+}
+
+@report{RFC7235,
+  type = {Request for Comments},
+  title = {Hypertext {{Transfer Protocol}} ({{HTTP}}/1.1): {{Authentication}}},
+  shorttitle = {Hypertext {{Transfer Protocol}} ({{HTTP}}/1.1)},
+  author = {Fielding, Roy T. and Reschke, Julian},
+  date = {2014-06},
+  number = {RFC 7235},
+  institution = {Internet Engineering Task Force},
+  doi = {10.17487/RFC7235},
+  url = {https://datatracker.ietf.org/doc/rfc7235},
+  urldate = {2025-01-03},
+  abstract = {The Hypertext Transfer Protocol (HTTP) is a stateless application- level protocol for distributed, collaborative, hypermedia information systems. This document defines the HTTP Authentication framework.},
+  pagetotal = {19},
+  file = {C:\Users\victo\Zotero\storage\VQAKPJ2L\Fielding and Reschke - 2014 - Hypertext Transfer Protocol (HTTP1.1) Authentication.pdf}
+}
+
+@report{RFC4634,
+  type = {Request for Comments},
+  title = {{{US Secure Hash Algorithms}} ({{SHA}} and {{HMAC-SHA}})},
+  author = {Hansen, Tony and Eastlake 3rd, Donald E.},
+  date = {2006-08},
+  number = {RFC 4634},
+  institution = {Internet Engineering Task Force},
+  doi = {10.17487/RFC4634},
+  url = {https://datatracker.ietf.org/doc/rfc4634},
+  urldate = {2025-01-03},
+  abstract = {The United States of America has adopted a suite of Secure Hash Algorithms (SHAs), including four beyond SHA-1, as part of a Federal Information Processing Standard (FIPS), specifically SHA-224 (RFC 3874), SHA-256, SHA-384, and SHA-512. The purpose of this document is to make source code performing these hash functions conveniently available to the Internet community. The sample code supports input strings of arbitrary bit length. SHA-1's sample code from RFC 3174 has also been updated to handle input strings of arbitrary bit length. Most of the text herein was adapted by the authors from FIPS 180-2. Code to perform SHA-based HMACs, with arbitrary bit length text, is also included. This memo provides information for the Internet community.},
+  pagetotal = {108},
+  file = {C:\Users\victo\Zotero\storage\KB4CXMJT\Hansen and Eastlake 3rd - 2006 - US Secure Hash Algorithms (SHA and HMAC-SHA).pdf}
+}
+
+@report{RFC1459,
+  type = {Request for Comments},
+  title = {Internet {{Relay Chat Protocol}}},
+  date = {1993-05},
+  number = {RFC 1459},
+  institution = {Internet Engineering Task Force},
+  doi = {10.17487/RFC1459},
+  url = {https://datatracker.ietf.org/doc/rfc1459},
+  urldate = {2025-01-03},
+  abstract = {The IRC protocol is a text-based protocol, with the simplest client being any socket program capable of connecting to the server. This memo defines an Experimental Protocol for the Internet community.},
+  pagetotal = {65},
+  file = {C:\Users\victo\Zotero\storage\236FHI4M\1993 - Internet Relay Chat Protocol.pdf}
+}
+
+@report{RFC4251,
+  type = {Request for Comments},
+  title = {The {{Secure Shell}} ({{SSH}}) {{Protocol Architecture}}},
+  author = {Lonvick, Chris M. and Ylonen, Tatu},
+  date = {2006-01},
+  number = {RFC 4251},
+  institution = {Internet Engineering Task Force},
+  doi = {10.17487/RFC4251},
+  url = {https://datatracker.ietf.org/doc/rfc4251},
+  urldate = {2025-01-03},
+  abstract = {The Secure Shell (SSH) Protocol is a protocol for secure remote login and other secure network services over an insecure network. This document describes the architecture of the SSH protocol, as well as the notation and terminology used in SSH protocol documents. It also discusses the SSH algorithm naming system that allows local extensions. The SSH protocol consists of three major components: The Transport Layer Protocol provides server authentication, confidentiality, and integrity with perfect forward secrecy. The User Authentication Protocol authenticates the client to the server. The Connection Protocol multiplexes the encrypted tunnel into several logical channels. Details of these protocols are described in separate documents. [STANDARDS-TRACK]},
+  pagetotal = {30},
+  file = {C:\Users\victo\Zotero\storage\D4S9HRVH\Lonvick and Ylonen - 2006 - The Secure Shell (SSH) Protocol Architecture.pdf}
+}
+
+@report{RFC6455,
+  type = {Request for Comments},
+  title = {The {{WebSocket Protocol}}},
+  author = {Melnikov, Alexey and Fette, Ian},
+  date = {2011-12},
+  number = {RFC 6455},
+  institution = {Internet Engineering Task Force},
+  doi = {10.17487/RFC6455},
+  url = {https://datatracker.ietf.org/doc/rfc6455},
+  urldate = {2025-01-03},
+  abstract = {The WebSocket Protocol enables two-way communication between a client running untrusted code in a controlled environment to a remote host that has opted-in to communications from that code. The security model used for this is the origin-based security model commonly used by web browsers. The protocol consists of an opening handshake followed by basic message framing, layered over TCP. The goal of this technology is to provide a mechanism for browser-based applications that need two-way communication with servers that does not rely on opening multiple HTTP connections (e.g., using XMLHttpRequest or \textbackslash textlessiframe\textbackslash textgreaters and long polling). [STANDARDS-TRACK]},
+  pagetotal = {71},
+  file = {C:\Users\victo\Zotero\storage\TDNANTG6\Melnikov and Fette - 2011 - The WebSocket Protocol.pdf}
+}

--- a/src/rfc/rfc-00.typ
+++ b/src/rfc/rfc-00.typ
@@ -82,7 +82,7 @@ With this, members are expected to hold the following responsibilities with rega
 
 = Style Guide
 
-All RFCs will abide by the following points of style, guided in part by the IETF RFC 7322.
+All RFCs will abide by the following points of style, guided in part by the #link("https://www.rfc-editor.org/rfc/rfc7322")[IETF RFC 7322].
 
 == Style conventions
 

--- a/src/rfc/rfc-00.typ
+++ b/src/rfc/rfc-00.typ
@@ -19,6 +19,6 @@
 
 == The Engineering Committee Member
 
-= RFC Standards
-
 = Style Guide
+
+== Parts of an RFC

--- a/src/rfc/rfc-00.typ
+++ b/src/rfc/rfc-00.typ
@@ -3,6 +3,8 @@
 #show: project.with(
     "RFC-00: Requests for Comments",
     authors: ("Victor Edwin Reyes",),
+    status: draft-status,
+    abstract: "The Engineering Committee needs a document format to record its decisions. This document provides a rationale for the RFC, defines its purpose, specifies the roles of stakeholders, and provides a style guide."
 )
 
 = Request for Comments

--- a/src/rfc/rfc-00.typ
+++ b/src/rfc/rfc-00.typ
@@ -121,7 +121,19 @@ All RFCs will abide by the following points of style, guided in part by the IETF
 
 - RFCs shall use the IEEE format.
 
+=== Writing Style
+
+- RFCs shall encode the following information:
+    - *Imperative directives* outlining Engineering Committee policies and best practices, and
+    - *Narratives or information* briefly discussing the reasoning for the best practices
+
+- RFCs must exhibit a clear delineation between both
+
+- RFCs must make it especially easy to locate and identify _directives_ for rapid referencing
+
 == Structure
+
+- An RFC must contain the sections enumerated herein. Unless otherwise prohibited by this standard; however, the addition of new sections is allowed.
 
 === Preamble
 

--- a/src/rfc/rfc-00.typ
+++ b/src/rfc/rfc-00.typ
@@ -61,6 +61,11 @@ The Director for Engineering, as head of the committee, reserves the right to th
 + To designate *RFC numbers*
 + To accept or reject RFC drafts, elevating them to the status of #adopted-status
 
+With this, the Director is expected to hold the following responsibilities with regard to RFCs:
++ To ensure that members of the committee are aware of and adhere to the provisions of each adopted RFC
++ To ensure that RFCs continue to be written and published by the committee for the benefit of its members and its readers
++ To ensure that all RFCs adhere to the writing standards outlined within this document
+
 == The Engineering Committee Member
 
 = Style Guide

--- a/src/rfc/rfc-00.typ
+++ b/src/rfc/rfc-00.typ
@@ -108,6 +108,11 @@ All RFCs will abide by the following points of style, guided in part by the IETF
 
 === Capitalization
 
+- Capitalization must be consistent within the document, and ideally with related RFCs
+
+- The major words in RFC headers and titles should be capitalized (similar to "title case")
+    - RFC headers and titles in sentence-form may deviate from this specification
+
 === Citation
 
 == Structure

--- a/src/rfc/rfc-00.typ
+++ b/src/rfc/rfc-00.typ
@@ -56,6 +56,11 @@ This section defines the roles that stakeholders within the Engineering Committe
 
 == The Director for Engineering
 
+The Director for Engineering, as head of the committee, reserves the right to the following:
++ To modify the format of RFCs or to otherwise modify this standard
++ To designate *RFC numbers*
++ To accept or reject RFC drafts, elevating them to the status of #adopted-status
+
 == The Engineering Committee Member
 
 = Style Guide

--- a/src/rfc/rfc-00.typ
+++ b/src/rfc/rfc-00.typ
@@ -50,7 +50,7 @@ The *Request for Comments* is made with three purposes:
 
     The RFC is a standard and a record, but not a lone source of truth. It must be able to challenge its readers to take on the standard for justifiable reasons. Similarly; however, it can be challenged. _It must be challenged_.
 
-= Roles and Responsibilities
+= Roles and Responsibilities <roles-and-resp>
 
 This section defines the roles that stakeholders within the Engineering Committee are supposed to play within the process of drafting, publishing, and approving RFCs.
 

--- a/src/rfc/rfc-00.typ
+++ b/src/rfc/rfc-00.typ
@@ -19,6 +19,20 @@ For example, anyone can build an Internet Relay Chat (IRC) system simply by comp
 
 == The Engineering Committee RFC
 
+In accordance with the UP CSI Constitution of 2024, Article V, Section 3, the Engineering Committee is responsible for serving as technical consultants and quality assurers for the organization's projects.
+
+As of the 2425A semester, this responsibility has extended to handling the technical education and training of the organization's developers.
+
+Previous terms have resulted in the adoption of new technologies and standards such as SvelteKit and Git commit conventions. These have been included, and to some extent _codified_, in the committee's trademark Developer Training Program (DTP) and DevCamp (DC). 
+
+However, educational materials are not made for the purpose of rigorously codifying and justifying standards. DTP and DC materials are not strictly reference materials, and would be difficult to specifically reference or use as a foundation for arguments. 
+
+Similarly, codifying the Committee's smaller design or technical decisions becomes more difficult in the format of the training modules.
+
+A format is needed that is not educational - that does not need to teach, but to assert. 
+
+Thus, in order to define, preserve, and defend the _technical decisions, standards, and policies_ of the Engineering Committee, the *Engineering Committee Request for Comments* is defined herein.
+
 === The Purpose of the RFC
 
 = Roles and Responsibilities

--- a/src/rfc/rfc-00.typ
+++ b/src/rfc/rfc-00.typ
@@ -100,7 +100,11 @@ All RFCs will abide by the following points of style, guided in part by the IETF
 
 === Punctuation
 
+- No overstriking or underlining is allowed
 
+- A comma is used before the last item of a series
+
+- When quoting literal text, punctuation marks belong outside of the quotation marks unless they are part of the original quote
 
 === Capitalization
 

--- a/src/rfc/rfc-00.typ
+++ b/src/rfc/rfc-00.typ
@@ -141,7 +141,7 @@ All RFCs will abide by the following points of style, guided in part by the IETF
 
 - The preamble shall comprise the first page of an RFC
 
-- The preamble shall be made up of the following elements:
+- The preamble shall be made up of the following elements, in order:
 
 ==== Title
 
@@ -168,3 +168,9 @@ All RFCs will abide by the following points of style, guided in part by the IETF
 - The usage of these statuses shall abide by the provisions in #ref(<roles-and-resp>)
 
 ==== Abstract
+
+- An RFC shall have an abstract to provide a concise and comprehensive overview of its contents.
+
+- An abstract shall not exceed 150 words in length.
+
+- The abstract shall ideally begin with the words "This document..." or "This standard..."

--- a/src/rfc/rfc-00.typ
+++ b/src/rfc/rfc-00.typ
@@ -90,6 +90,10 @@ All RFCs will abide by the following points of style, guided in part by the IETF
 
 RFCs will be identified by at least two digits ("RFC-XX") and shall be assigned consecutively. 
 
+Individual RFCs, once published as an #adopted-status, are not to be amended except for typographical, grammatical, or stylistic changes. 
+
+Obsolete RFCs are to be replaced with a new RFC and indicated by the status #obsoleted-status("[new rfc]").
+
 === File Format
 
 === Punctuation

--- a/src/rfc/rfc-00.typ
+++ b/src/rfc/rfc-00.typ
@@ -159,4 +159,12 @@ All RFCs will abide by the following points of style, guided in part by the IETF
 
 ==== Status
 
+- An RFC may have one of four statuses:
+    - #draft-status (encoded as `#draft-status` in Typst)
+    - #proposed-status (encoded as `#proposed-status` in Typst)
+    - #adopted-status (encoded as `#adopted-status` in Typst)
+    - #obsoleted-status("RFC-XX") (encoded as `#obsoleted-status("RFC-XX")` in Typst)
+
+- The usage of these statuses shall abide by the provisions in #ref(<roles-and-resp>)
+
 ==== Abstract

--- a/src/rfc/rfc-00.typ
+++ b/src/rfc/rfc-00.typ
@@ -96,6 +96,8 @@ Obsolete RFCs are to be replaced with a new RFC and indicated by the status #obs
 
 === File Format
 
+RFCs must be written in the Typst markdown language using the prescribed template.
+
 === Punctuation
 
 === Capitalization

--- a/src/rfc/rfc-00.typ
+++ b/src/rfc/rfc-00.typ
@@ -82,4 +82,24 @@ With this, members are expected to hold the following responsibilities with rega
 
 = Style Guide
 
-== Parts of an RFC
+== Style conventions
+
+=== RFC Numbering
+
+=== File Format
+
+=== Punctuation
+
+=== Capitalization
+
+=== Citation
+
+== Structure
+
+=== Preamble
+
+==== Author
+
+==== Status
+
+==== Abstract

--- a/src/rfc/rfc-00.typ
+++ b/src/rfc/rfc-00.typ
@@ -143,6 +143,8 @@ All RFCs will abide by the following points of style, guided in part by the #lin
 
 - RFCs must make it especially easy to locate and identify _directives_ for rapid referencing
 
+- In the event of a dispute regarding writing style or tone, the *Director for Engineering* shall be the final arbiter.
+
 == Structure
 
 - An RFC must contain the sections enumerated herein. Unless otherwise prohibited by this standard; however, the addition of new sections is allowed.

--- a/src/rfc/rfc-00.typ
+++ b/src/rfc/rfc-00.typ
@@ -137,6 +137,14 @@ All RFCs will abide by the following points of style, guided in part by the IETF
 
 === Preamble
 
+- The preamble of an RFC shall serve as an informative introduction to the contents of an RFC
+
+- The preamble shall comprise the first page of an RFC
+
+- The preamble shall be made up of the following elements:
+
+==== Title
+
 ==== Author
 
 ==== Status

--- a/src/rfc/rfc-00.typ
+++ b/src/rfc/rfc-00.typ
@@ -68,6 +68,18 @@ With this, the Director is expected to hold the following responsibilities with 
 
 == The Engineering Committee Member
 
+Members of the Engineering Committee reserve the right to the following:
++ To propose RFCs with status #draft-status, indicating that they are standards in the process of being written
++ To propose RFCs with status #proposed-status, indicating that they are standards that have been raised for the Director's approval
++ To endorse RFCs of either status written by non-members and receive recognition as co-authors, provided that due credit is given to the original authors
++ To comment on proposed RFCs
+
+With this, members are expected to hold the following responsibilities with regard to RFCs:
++ To be aware of and advise others on the provisions contained within the RFCs
++ To abide by and make use of the provisions of adopted RFCs
++ To ensure that all standards, proposed and adopted, are technically sound
++ To question and critique all standards on grounds of technical soundness, alignment with our values, and relevance
+
 = Style Guide
 
 == Parts of an RFC

--- a/src/rfc/rfc-00.typ
+++ b/src/rfc/rfc-00.typ
@@ -25,15 +25,28 @@ As of the 2425A semester, this responsibility has extended to handling the techn
 
 Previous terms have resulted in the adoption of new technologies and standards such as SvelteKit and Git commit conventions. These have been included, and to some extent _codified_, in the committee's trademark Developer Training Program (DTP) and DevCamp (DC). 
 
-However, educational materials are not made for the purpose of rigorously codifying and justifying standards. DTP and DC materials are not strictly reference materials, and would be difficult to specifically reference or use as a foundation for arguments. 
+However, educational materials are not made for the purpose of rigorously codifying and justifying standards. DTP and DC materials are not strictly reference materials, and would be difficult to specifically reference or use as a foundation for arguments. Not to mention, educational materials are not strictly made to be questioned.
 
 Similarly, codifying the Committee's smaller design or technical decisions becomes more difficult in the format of the training modules.
 
-A format is needed that is not educational - that does not need to teach, but to assert. 
+A format is needed that is not educational - that does not need to teach, but to assert and to be freely challenged. 
 
 Thus, in order to define, preserve, and defend the _technical decisions, standards, and policies_ of the Engineering Committee, the *Engineering Committee Request for Comments* is defined herein.
 
 === The Purpose of the RFC
+
+The *Request for Comments* is made with three purposes:
+- To *record* the decisions of the Engineering Committee
+
+    The RFC must be able to serve as the Committee's memory and as its voice. Any RFC adopted as a standard carries the opinion of the Committee to its readers inside and outside the organization and forward into the future.
+
+- To *define*, rigorously, the technical points and implications of these decisions
+
+    The RFC must be able to serve as a manual for anyone who wants to adopt these same standards. The same way an _IETF RFC_ defines a protocol that can be adopted to interface with other adopters, so must implementations of an _Engineering RFC_ be intercompatible.
+
+- To *justify* these decisions and their implications, with the intent of soliciting _comments_
+
+    The RFC is a standard and a record, but not a lone source of truth. It must be able to challenge its readers to take on the standard for justifiable reasons. Similarly; however, it can be challenged. _It must be challenged_.
 
 = Roles and Responsibilities
 

--- a/src/rfc/rfc-00.typ
+++ b/src/rfc/rfc-00.typ
@@ -52,6 +52,8 @@ The *Request for Comments* is made with three purposes:
 
 = Roles and Responsibilities
 
+This section defines the roles that stakeholders within the Engineering Committee are supposed to play within the process of drafting, publishing, and approving RFCs.
+
 == The Director for Engineering
 
 == The Engineering Committee Member

--- a/src/rfc/rfc-00.typ
+++ b/src/rfc/rfc-00.typ
@@ -9,6 +9,14 @@
 
 == The IETF RFC
 
+#link("https://www.ietf.org/process/rfcs/")[Requests for Comments] are documents published by the Internet Engineering Task Force as their technical documentation. They serve as technical specifications for foundational concepts, systems, and protocols that underpin the internet. 
+
+Such systems include the Hypertext Transfer Protocol (HTTP; #link("https://datatracker.ietf.org/doc/html/rfc7230")[RFC 7230] to #link("https://datatracker.ietf.org/doc/html/rfc7235")[RFC 7235]), WebSockets (#link("https://datatracker.ietf.org/doc/html/rfc6455")[RFC 6455]), Secure Shell (SSH; #link("https://datatracker.ietf.org/doc/html/rfc4251")[RFC 4251]), Secure Hash Algorithms (SHA; #link("https://www.rfc-editor.org/rfc/rfc4634")[RFC 4634]), and many, many others.
+
+Each of the above listed technologies has an associated RFC which describes their specifications. Looking from the outside in, they effectively define interfaces that can be used to communicate with any systems that comply with their specifications. 
+
+For example, anyone can build an Internet Relay Chat (IRC) system simply by complying with the specifications of #link("https://datatracker.ietf.org/doc/html/rfc1459")[RFC 1459] (and other RFCs). RFC 1459, in Section #link("https://datatracker.ietf.org/doc/html/rfc1459#section-4")[4] specifies the formats of messages any IRC application should be able to recognize.
+
 == The Engineering Committee RFC
 
 === The Purpose of the RFC

--- a/src/rfc/rfc-00.typ
+++ b/src/rfc/rfc-00.typ
@@ -88,17 +88,19 @@ All RFCs will abide by the following points of style, guided in part by the IETF
 
 === RFC Numbering
 
-RFCs will be identified by at least two digits ("RFC-XX") and shall be assigned consecutively. 
+- RFCs will be identified by at least two digits ("RFC-XX") and shall be assigned consecutively. 
 
-Individual RFCs, once published as an #adopted-status, are not to be amended except for typographical, grammatical, or stylistic changes. 
+- Individual RFCs, once published as an #adopted-status, are not to be amended except for typographical, grammatical, or stylistic changes. 
 
-Obsolete RFCs are to be replaced with a new RFC and indicated by the status #obsoleted-status("[new rfc]").
+- Obsolete RFCs are to be replaced with a new RFC and indicated by the status #obsoleted-status("[new rfc]").
 
 === File Format
 
-RFCs must be written in the Typst markdown language using the prescribed template.
+- RFCs must be written in the Typst markdown language using the prescribed template.
 
 === Punctuation
+
+
 
 === Capitalization
 

--- a/src/rfc/rfc-00.typ
+++ b/src/rfc/rfc-00.typ
@@ -151,6 +151,12 @@ All RFCs will abide by the following points of style, guided in part by the IETF
 
 ==== Author
 
+- An RFC's authors shall include all persons who directly contributed to _both_ its writing and formulation, including non-Engineering Committee members
+
+- The main author of an RFC (that is, the author identified as having provided the most material contributions to the document) shall be placed at the top of the authors' list. All others thereafter shall be included alphabetically.
+
+- The authors of obsoleted RFCs need not be included in succeeding RFCs, unless they have directly contributed to the new document.
+
 ==== Status
 
 ==== Abstract

--- a/src/rfc/rfc-00.typ
+++ b/src/rfc/rfc-00.typ
@@ -96,7 +96,7 @@ All RFCs will abide by the following points of style, guided in part by the #lin
 
 === File Format
 
-- RFCs must be written in the Typst markdown language using the prescribed template.
+- RFCs must be written in the Typst language using the prescribed template.
 
 - The source files for RFCs must be stored in the RFC repository under the `src/rfc` directory as files named `rfc-xx.typ`
 

--- a/src/rfc/rfc-00.typ
+++ b/src/rfc/rfc-00.typ
@@ -115,7 +115,7 @@ All RFCs will abide by the following points of style, guided in part by the #lin
 - The major words in RFC headers and titles should be capitalized (similar to "title case")
     - RFC headers and titles in sentence-form may deviate from this specification
 
-=== Citation
+=== Citation <citation>
 
 - The bibliography file for an RFC will be stored in the same folder as the RFC source code in the `.bib` format as `rfc-xx.bib`.
 
@@ -176,5 +176,7 @@ All RFCs will abide by the following points of style, guided in part by the #lin
 - The abstract shall ideally begin with the words "This document..." or "This standard..."
 
 === Bibliography
+
+- A bibliography shall be included at the end of the document, titled "Bibliography" and shall be in the style specified in #ref(<citation>)
 
 #bibliography("rfc-00.bib")

--- a/src/rfc/rfc-00.typ
+++ b/src/rfc/rfc-00.typ
@@ -174,3 +174,7 @@ All RFCs will abide by the following points of style, guided in part by the IETF
 - An abstract shall not exceed 150 words in length.
 
 - The abstract shall ideally begin with the words "This document..." or "This standard..."
+
+=== Bibliography
+
+#bibliography("rfc-00.bib")

--- a/src/rfc/rfc-00.typ
+++ b/src/rfc/rfc-00.typ
@@ -117,7 +117,9 @@ All RFCs will abide by the following points of style, guided in part by the IETF
 
 === Citation
 
-- The bibliography file for an RFC will be stored
+- The bibliography file for an RFC will be stored in the same folder as the RFC source code in the `.bib` format as `rfc-xx.bib`.
+
+- RFCs shall use the IEEE format.
 
 == Structure
 

--- a/src/rfc/rfc-00.typ
+++ b/src/rfc/rfc-00.typ
@@ -123,6 +123,18 @@ All RFCs will abide by the following points of style, guided in part by the #lin
 
 === Writing Style
 
+- Leeway is given to authors as to the style and tone of an RFC, but for the sake of consistency, a uniform style must be enforced.
+
+- An RFC must be professional, from tone to grammar and word choice.
+
+- An RFC must be informational in tone and assumes that the reader intends to or must follow the directives stated.
+    - Additional information, such as the context behind or consequences of certain decisions is encouraged, but is not the main point of an RFC
+
+- An RFC must be written in the third person. 
+
+- The grammar of an RFC does not need to strictly adhere to any variant of English, so long as it is universally understandable.
+    - If a reference variant must be specified, preference should be given to American English.
+
 - RFCs shall encode the following information:
     - *Imperative directives* outlining Engineering Committee policies and best practices, and
     - *Narratives or information* briefly discussing the reasoning for the best practices

--- a/src/rfc/rfc-00.typ
+++ b/src/rfc/rfc-00.typ
@@ -13,7 +13,7 @@
 
 #link("https://www.ietf.org/process/rfcs/")[Requests for Comments] are documents published by the Internet Engineering Task Force as their technical documentation. They serve as technical specifications for foundational concepts, systems, and protocols that underpin the internet. 
 
-Such systems include the Hypertext Transfer Protocol (HTTP; #link("https://datatracker.ietf.org/doc/html/rfc7230")[RFC 7230] to #link("https://datatracker.ietf.org/doc/html/rfc7235")[RFC 7235]), WebSockets (#link("https://datatracker.ietf.org/doc/html/rfc6455")[RFC 6455]), Secure Shell (SSH; #link("https://datatracker.ietf.org/doc/html/rfc4251")[RFC 4251]), Secure Hash Algorithms (SHA; #link("https://www.rfc-editor.org/rfc/rfc4634")[RFC 4634]), and many, many others.
+Such systems include the Hypertext Transfer Protocol (HTTP; #link("https://datatracker.ietf.org/doc/html/rfc7230")[RFC 7230] #cite(<RFC7230>) to #link("https://datatracker.ietf.org/doc/html/rfc7235")[RFC 7235]) #cite(<RFC7235>), WebSockets (#link("https://datatracker.ietf.org/doc/html/rfc6455")[RFC 6455]) #cite(<RFC6455>), Secure Shell (SSH; #link("https://datatracker.ietf.org/doc/html/rfc4251")[RFC 4251]) #cite(<RFC4251>), Secure Hash Algorithms (SHA; #link("https://www.rfc-editor.org/rfc/rfc4634")[RFC 4634]) #cite(<RFC4634>), and many, many others.
 
 Each of the above listed technologies has an associated RFC which describes their specifications. Looking from the outside in, they effectively define interfaces that can be used to communicate with any systems that comply with their specifications. 
 
@@ -82,7 +82,7 @@ With this, members are expected to hold the following responsibilities with rega
 
 = Style Guide
 
-All RFCs will abide by the following points of style, guided in part by the #link("https://www.rfc-editor.org/rfc/rfc7322")[IETF RFC 7322].
+All RFCs will abide by the following points of style, guided in part by the #link("https://www.rfc-editor.org/rfc/rfc7322")[IETF RFC 7322] #cite(<RFC7322>).
 
 == Style conventions
 

--- a/src/rfc/rfc-00.typ
+++ b/src/rfc/rfc-00.typ
@@ -5,4 +5,20 @@
     authors: ("Victor Edwin Reyes",),
 )
 
-= The Request for Comments
+= Request for Comments
+
+== The IETF RFC
+
+== The Engineering Committee RFC
+
+=== The Purpose of the RFC
+
+= Roles and Responsibilities
+
+== The Director for Engineering
+
+== The Engineering Committee Member
+
+= RFC Standards
+
+= Style Guide

--- a/src/rfc/rfc-00.typ
+++ b/src/rfc/rfc-00.typ
@@ -82,9 +82,13 @@ With this, members are expected to hold the following responsibilities with rega
 
 = Style Guide
 
+All RFCs will abide by the following points of style, guided in part by the IETF RFC 7322.
+
 == Style conventions
 
 === RFC Numbering
+
+RFCs will be identified by at least two digits ("RFC-XX") and shall be assigned consecutively. 
 
 === File Format
 

--- a/src/rfc/rfc-00.typ
+++ b/src/rfc/rfc-00.typ
@@ -92,11 +92,13 @@ All RFCs will abide by the following points of style, guided in part by the IETF
 
 - Individual RFCs, once published as an #adopted-status, are not to be amended except for typographical, grammatical, or stylistic changes. 
 
-- Obsolete RFCs are to be replaced with a new RFC and indicated by the status #obsoleted-status("[new rfc]").
+- Obsolete RFCs are to be replaced with a new RFC and indicated by the status #obsoleted-status("RFC-XX").
 
 === File Format
 
 - RFCs must be written in the Typst markdown language using the prescribed template.
+
+- The source files for RFCs must be stored in the RFC repository under the `src/rfc` directory as files named `rfc-xx.typ`
 
 === Punctuation
 
@@ -114,6 +116,8 @@ All RFCs will abide by the following points of style, guided in part by the IETF
     - RFC headers and titles in sentence-form may deviate from this specification
 
 === Citation
+
+- The bibliography file for an RFC will be stored
 
 == Structure
 

--- a/src/rfc/rfc-00.typ
+++ b/src/rfc/rfc-00.typ
@@ -145,6 +145,10 @@ All RFCs will abide by the following points of style, guided in part by the IETF
 
 ==== Title
 
+- An RFC shall be titled according to the format: "RFC-XX: [SUBTITLE]"
+
+- The subtitle of an RFC must be related to the topic and discusses and refer specifically to the item(s) it lays down standards for (e.g. "Git Standards" instead of "On Git Standards" or "On the usage of Git")
+
 ==== Author
 
 ==== Status


### PR DESCRIPTION
This PR adds RFC-00, which defines the Request for Comments and sets our a style guide for future implementors of such. It also lays out the roles and responsibilities of Engineering Committee members in relation to it.

Upon merging into `main`, the status of this RFC will become `#adopted-status`.