### PR TITLE
deps: update dependencies

### DIFF
--- a/src/template.typ
+++ b/src/template.typ
@@ -1,6 +1,6 @@
 // Import necessary packages.
-#import "@preview/codelst:2.0.0": code-frame
-#import "@preview/showybox:2.0.1": showybox
+#import "@preview/codelst:2.0.2": code-frame
+#import "@preview/showybox:2.0.4": showybox
 
 // Define RFC statuses
 #let draft-status = text(


### PR DESCRIPTION
This PR updates the dependencies listed in `src/template.typ` in order to make `typst preview` work.